### PR TITLE
Passed 'mode' argument to LangChain wrapper

### DIFF
--- a/langchain/vectorstores/lance_dataset.py
+++ b/langchain/vectorstores/lance_dataset.py
@@ -179,18 +179,22 @@ class LanceDataset(VectorStore):
 
         return cls(embedding.embed_query, uri)
 
-    def save_local(self, uri: str) -> None:
+    def save_local(self, uri: str, mode: str) -> None:
         """Save Lance dataset to disk
-
         Args:
             uri: where to save the lance dataset
+            mode: str
+                **create** - create a new dataset (raises if uri already exists).
+                **overwrite** - create a new snapshot version
+                **append** - create a new version that is the concat of the input the
+                latest version (raises if uri does not exist)
         """
         path = Path(uri)
         path.mkdir(exist_ok=True, parents=True)
 
         # save index separately since it is not picklable
         lance = dependable_lance_import()[0]
-        lance.write_dataset(self.dataset.to_table(), str(path))
+        lance.write_dataset(self.dataset.to_table(), str(path), mode=mode)
 
     @classmethod
     def load_local(cls, uri: str, embeddings: Embeddings) -> LanceDataset:


### PR DESCRIPTION
Apologies if this was excluded for a reason I am not understanding. Lance and the LanceDataset VectorStore are the most clean and effective method I've found for fast I/O for local chat bots. Allowing appending will let me to work with just the VectorStore implementation thanks to the save/local_load methods (which are conspicuously missing from other VecStore implementations). I hope to see the Lance pull request accepted soon, but in the interim thought I would share so as to not have to rely on my own local versions when updating packages, or in the worst case, be told how I should actually be doing this if not the way I've proposed.